### PR TITLE
Custom filtering of perkviewset with map

### DIFF
--- a/zombies/api/serializers.py
+++ b/zombies/api/serializers.py
@@ -1,3 +1,4 @@
+from rest_framework.fields import SerializerMethodField
 from rest_framework.serializers import ModelSerializer
 
 from ..models import Map, Perk, GobbleGum, RandomFact, MapFact
@@ -10,9 +11,14 @@ class MapSerializer(ModelSerializer):
 
 
 class PerkSerializer(ModelSerializer):
+    map = SerializerMethodField(source='get_map')
+
     class Meta:
         model = Perk
-        fields = ('perk_id', 'name', 'location')
+        fields = ('perk_id', 'name', 'location', 'map')
+
+    def get_map(self, obj):
+        return obj.map.name
 
 
 class GobbleGumSerializer(ModelSerializer):

--- a/zombies/api/views.py
+++ b/zombies/api/views.py
@@ -13,7 +13,19 @@ class MapViewSet(ModelViewSet):
 class PerkViewSet(ModelViewSet):
     serializer_class = PerkSerializer
     queryset = Perk.objects.all()
-    filter_fields = ['perk_id', 'name', 'map__map_id']
+    filter_fields = ['perk_id']
+
+    def get_queryset(self):
+        """
+        Allow case insensitive filtering of map name
+        """
+        queryset = super().get_queryset()
+
+        map = self.request.query_params.get('map', None)
+        if map is not None:
+            queryset = queryset.filter(map__name__icontains=map)
+
+        return queryset
 
 
 class GobbleGumViewSet(ModelViewSet):


### PR DESCRIPTION
- returns a map name with the perkserializer
- allows custom filtering of perks with `map` parameter (case insensitive) 